### PR TITLE
Upgrade required for Gatsby v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Quick and dirty firebase source for Gatsby. Allows you to query your firebase da
 
 ## Usage
 
+```
+npm install gatsby-source-firebase
+```
+
+*Note: For older versions of Gatsby (v1, v2) use:* `gatsby-source-firebase@1.0.0`
+
 1. First you need a Private Key from firebase for privileged environments, find out how to get it here: https://firebase.google.com/docs/admin/setup (or click the settings gear > Service accounts tab > Generate New Private Key button at the bottom)
 
 2. Place that private key .json file somewhere in your gatsby project (the root is fine).

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -2,11 +2,11 @@ const firebase = require("firebase-admin")
 const crypto = require("crypto")
 
 exports.sourceNodes = (
-  { boundActionCreators },
+  { actions },
   { credential, databaseURL, types, quiet = false },
   done
 ) => {
-  const { createNode } = boundActionCreators
+  const { createNode } = actions
 
   firebase.initializeApp({
     credential: firebase.credential.cert(credential),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-firebase",
-  "version": "1.0.0",
+  "version": "3.0.0",
   "description": "Gatsby plugin to turn Firebase into a Gatsby data source.",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Simple update for [breaking change](https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v2-to-v3/#removal-of-boundactioncreators) introduced in Gatsby v3 ([Already deprecated in v2](https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v1-to-v2/#rename-boundactioncreators-to-actions))
Fixes https://github.com/ryanflorence/gatsby-source-firebase/issues/8

Also increased plugin version, to match Gatsby versioning.